### PR TITLE
Update valid_prog_environs for sphexa tests

### DIFF
--- a/checks/apps/sphexa/sphexa_uenv.py
+++ b/checks/apps/sphexa/sphexa_uenv.py
@@ -13,7 +13,7 @@ class sphexa_build(rfm.RunOnlyRegressionTest):
     descr = 'Clone and Build SPHEXA'
     maintainers = ['SSA']
     valid_systems = ['+remote']
-    valid_prog_environs = ['+sphexa']
+    valid_prog_environs = ['+mpi +cuda -cpe']
     sourcesdir = None
     branch = variable(str, value='develop')
     build_system = 'CustomBuild'
@@ -64,7 +64,7 @@ class sphexa_strong_scaling(rfm.RunOnlyRegressionTest):
     descr = 'Run SPHEXA'
     maintainers = ['SSA']
     valid_systems = ['+remote']
-    valid_prog_environs = ['+sphexa']
+    valid_prog_environs = ['+mpi +cuda -cpe']
 
     @run_after('init')
     def setup_dependency(self):


### PR DESCRIPTION
- [ ] Describe the purpose of this pull request (Add a link to the jira issue when possible)
- [ ] Share the command line used to run the test
```console
$ reframe -r ...
```

- You can manually trigger 1 (or more) CI pipelines by writing a comment in this Pull Request. For example:
  - CPE testing:  add `cscs-ci run alps-daint-cpe`
  - UENV testing: add `cscs-ci run alps-daint-uenv;MY_UENV=prgenv-gnu/25.06:rc5`
  - By default all UENVs will be tested: this is no longer true
  - Tested platforms: daint, santis, clariden, eiger, bristen, beverin

Thank you for taking the time to contribute to `cscs-reframe-tests` !
